### PR TITLE
Add scheduled workflow for data build

### DIFF
--- a/.github/workflows/fetch-and-build.yml
+++ b/.github/workflows/fetch-and-build.yml
@@ -1,0 +1,20 @@
+name: Fetch and build data
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+
+jobs:
+  fetch-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python scripts/fetch_and_build.py
+      - name: Upload data artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: data
+          path: data


### PR DESCRIPTION
## Summary
- add scheduled workflow to fetch Google Sheets data via `scripts/fetch_and_build.py`
- upload generated data as workflow artifact

## Testing
- `python scripts/fetch_and_build.py` (fails: URLError: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689fd7c3103c8325ae63ba131943406e